### PR TITLE
Add safety guard to database wipe and simulation script

### DIFF
--- a/docs/api/environment-api.md
+++ b/docs/api/environment-api.md
@@ -99,3 +99,10 @@ Canonical request/response schemas are in:
 - Main DB variable: `DATABASE_URL`
 - YAML config root: `services/environment-api/config/default.yaml`
 - Optional config override env var: `ENVIRONMENT_API_CONFIG`
+
+
+## Database data population
+It's important to provide --force-wipe flag to ensure that this process fully recreates db.
+```cli
+uv run python -m environment_api.data_generator.generate_seed_data --force-wipe
+```

--- a/services/environment-api/src/environment_api/data_generator/generate_seed_data.py
+++ b/services/environment-api/src/environment_api/data_generator/generate_seed_data.py
@@ -26,6 +26,7 @@ Dependencies:
     - SimulationEngine for dynamic event generation.
 """
 
+import argparse
 from datetime import UTC, datetime, timedelta
 
 from common.logging import configure_logging, get_logger
@@ -140,7 +141,21 @@ class SimulationRunner:
         session.commit()
 
 
-if __name__ == "__main__":
+def run_simulation() -> None:
+    parser = argparse.ArgumentParser(description="Database Management Script")
+    parser.add_argument(
+        "--force-wipe", action="store_true", help="Wipe and repopulate the database"
+    )
+    args = parser.parse_args()
+
+    if not args.force_wipe:
+        print("Safety check: --force-wipe flag not detected. No changes made.")
+        return
+
     engine = get_engine()
     runner = SimulationRunner(engine)
     runner.run(days=settings.simulation.default_days)
+
+
+if __name__ == "__main__":
+    run_simulation()


### PR DESCRIPTION
The current script automatically wipes and repopulates the database on every execution. To prevent accidental data loss in development or production environments, we need to implement a command-line safety guard using `argparse`.

**Requirements:**
* **Default-Safe:** The script must skip all destructive logic by default when run as `python script.py`.
* **Explicit Trigger:** Destructive actions should only execute if the `--force-wipe` flag is provided.
* **User Feedback:** If the flag is missing, the script should print a clear warning message explaining how to proceed and exit without modifying the database.

**Why this is important:**
This adds a "manual confirmation" step to the developer workflow, preventing "fat-finger" errors where a previous command is accidentally re-run from the terminal history.