### PR TITLE
Normalize agent skill identifiers and references

### DIFF
--- a/services/agent-service/skills/ds01_action_ranker/SKILL.md
+++ b/services/agent-service/skills/ds01_action_ranker/SKILL.md
@@ -3,10 +3,13 @@ name: expected-utility-action-ranker
 description: "Ranks candidate actions by expected utility and selects the best admissible action, accounting for uncertainty via confidence intervals. Filters out INFEASIBLE actions before ranking. Returns a ranked list with decision confidence (HIGH / MARGINAL / TIE). Use as the final selection step after scoring and constraint validation. Questions like 'Which action should we take?', 'What is the best replenishment option?', 'Rank these supplier choices.'"
 version: "1.0"
 tags: [action-ranking, MEU, decision, greedy, confidence, beam-search]
-dependencies: [SKILL-PU-01, SKILL-PU-03, SKILL-RE-01]
+dependencies:
+  - multi-attribute-utility-scorer
+  - constraint-satisfaction-validator
+  - inventory-uncertainty-quantifier
 ---
 
-# SKILL-DS-01 · Expected-Utility Action Ranker
+# Expected-Utility Action Ranker
 
 ## When to Use This Skill
 
@@ -35,10 +38,10 @@ function (Ch.7 §7.3, eq. 7.14):
 π(s) = argmax_a Q(s, a)     (eq. 7.14)
 ```
 
-Under uncertainty (`posterior_std > 0` from `SKILL-RE-01`), the utility
+Under uncertainty (`posterior_std > 0` from `inventory-uncertainty-quantifier`), the utility
 score has a confidence interval. If two actions' CIs overlap, the decision
 is MARGINAL or TIE and should be flagged for human review or escalated to
-`SKILL-MD-01`.
+`decision-confidence-estimator`.
 
 The **advantage function** (Ch.7 §7.3, eq. 7.15) provides the decision margin:
 
@@ -96,9 +99,9 @@ search_knowledge_base(
 ### Step 3: Collect scored and validated candidates
 
 Requires from upstream skills for each candidate action:
-- `action_utility_score` from `SKILL-PU-01`
-- `feasibility_status` from `SKILL-PU-03`
-- `uncertainty_index` from `SKILL-RE-01`
+- `action_utility_score` from `multi-attribute-utility-scorer`
+- `feasibility_status` from `constraint-satisfaction-validator`
+- `uncertainty_index` from `inventory-uncertainty-quantifier`
 
 **Filter step — eliminate inadmissible actions:**
 ```
@@ -116,7 +119,7 @@ Using the advantage function framing from Step 1:
 
 ```
 for each candidate a:
-    score(a)    = action_utility_score from SKILL-PU-01
+    score(a)    = action_utility_score from multi-attribute-utility-scorer
     ci_lower(a) = score(a) − 1.96 × uncertainty_index × 0.1
     ci_upper(a) = score(a) + 1.96 × uncertainty_index × 0.1
 
@@ -140,11 +143,11 @@ if margin > 0.10:
 elif margin > 0.02:
     decision_confidence = MARGINAL
 else:
-    decision_confidence = TIE    # escalate to SKILL-MD-03
+    decision_confidence = TIE    # escalate to signal-conflict-resolver
 
 # Tie-break when margin ≤ 0.02:
 #   1st: highest sla_priority
-#   2nd: highest posterior_mean_reliability (from SKILL-IA-02)
+#   2nd: highest posterior_mean_reliability (from supplier-reliability-aggregator)
 ```
 
 ---
@@ -169,7 +172,7 @@ else:
 |---|---|
 | All candidates INFEASIBLE | Return empty ranking, `data_gap_flag=True`, escalate |
 | Only one candidate | `margin=1.0`, `decision_confidence=HIGH` by default |
-| `SKILL-PU-01` not run | Cannot rank — require upstream scoring first |
+| `multi-attribute-utility-scorer` not run | Cannot rank — require upstream scoring first |
 | `uncertainty_index` unavailable | Use `CI = score ± 0.05` as conservative default |
 | All scores identical | `TIE`, apply tie-break rules, flag for human review |
 
@@ -227,16 +230,16 @@ Result:
   decision_confidence = MARGINAL
 
 Action A is recommended but the margin is very narrow (0.02).
-Action D is nearly equivalent — consider escalating to SKILL-MD-01
+Action D is nearly equivalent — consider escalating to `decision-confidence-estimator`
 to assess whether decision confidence is sufficient to execute,
-or to SKILL-MD-03 if signal conflict may explain the tie.
+or to `signal-conflict-resolver` if signal conflict may explain the tie.
 ```
 
 ---
 
 ## Feeds Into
 
-- `SKILL-MD-01` — uses `decision_confidence` and `margin` for overall confidence score
-- `SKILL-MD-03` — called when `decision_confidence = TIE` to resolve conflicts
-- `SKILL-MD-02` — called when `decision_confidence = MARGINAL` to evaluate deferral
-- `SKILL-PU-02` — if `TIE`, recomputes VOI to check if more info would break the tie
+- `decision-confidence-estimator` — uses `decision_confidence` and `margin` for overall confidence score
+- `signal-conflict-resolver` — called when `decision_confidence = TIE` to resolve conflicts
+- `decision-deferral-controller` — called when `decision_confidence = MARGINAL` to evaluate deferral
+- `value-of-information` — if `TIE`, recomputes VOI to check if more info would break the tie

--- a/services/agent-service/skills/ds02_dominance_filter/SKILL.md
+++ b/services/agent-service/skills/ds02_dominance_filter/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: stochastic-dominance-filter
-description: "Filters a set of candidate actions down to the Pareto frontier by removing actions that are dominated — worse than some alternative on every utility attribute simultaneously. Returns only non-dominated actions to reduce the decision set before final ranking. Use between SKILL-PU-01 (scoring) and SKILL-DS-01 (ranking) when there are 4+ candidates. Questions like 'Which options can we rule out entirely?', 'Are there any strictly inferior choices here?', 'Trim the candidate list before we decide.'"
+description: "Filters a set of candidate actions down to the Pareto frontier by removing actions that are dominated — worse than some alternative on every utility attribute simultaneously. Returns only non-dominated actions to reduce the decision set before final ranking. Use between `multi-attribute-utility-scorer` (scoring) and `expected-utility-action-ranker` (ranking) when there are 4+ candidates. Questions like 'Which options can we rule out entirely?', 'Are there any strictly inferior choices here?', 'Trim the candidate list before we decide.'"
 version: "1.0"
 tags: [dominance, pareto, pruning, filtering, multi-attribute, decision]
-dependencies: [SKILL-PU-01]
+dependencies:
+  - multi-attribute-utility-scorer
 ---
 
-# SKILL-DS-02 · Stochastic Dominance Filter
+# Stochastic Dominance Filter
 
 ## When to Use This Skill
 
@@ -14,7 +15,7 @@ Activate this skill when the user asks about:
 - Eliminating clearly inferior options before final ranking
 - Which actions can be ruled out without loss of optimality
 - Reducing a large candidate set (≥ 4 actions) to a tractable frontier
-- As an intermediate filter between `SKILL-PU-01` (scoring) and `SKILL-DS-01` (ranking)
+- As an intermediate filter between `multi-attribute-utility-scorer` (scoring) and `expected-utility-action-ranker` (ranking)
 - Questions like *"We have six replenishment options — which can we drop immediately?"*
   or *"Are any of these supplier choices strictly worse than the others?"*
 
@@ -90,13 +91,13 @@ get_entity_by_number(number="20.16")
 
 ---
 
-### Step 3: Retrieve utility breakdowns from SKILL-PU-01
+### Step 3: Retrieve utility breakdowns from `multi-attribute-utility-scorer`
 
 Requires for each candidate action:
 - `utility_breakdown`: `{u_fill, u_penalty, u_lt, u_sla}` — all four
   attribute-level utility scores (not just the weighted scalar)
 - `action_id`: identifier for the action
-- `feasibility_status` from `SKILL-PU-03` (if available)
+- `feasibility_status` from `constraint-satisfaction-validator` (if available)
 
 **Pre-filter:** remove any action with `feasibility_status = INFEASIBLE`
 before running dominance checks. Infeasible actions are already eliminated;
@@ -198,7 +199,7 @@ near_dominated = [
 | No candidate dominates any other (all on frontier) | Return full set, `dominated_actions=[]`, warn that DS-01 must break the tie |
 | `utility_breakdown` missing for some actions | Skip those actions from dominance check, add `data_gap_flag=True` |
 | All candidates have identical breakdowns | Return all as frontier (no dominance), flag `all_tied=True` |
-| `SKILL-PU-03` not run (no feasibility info) | Run dominance on all candidates, add warning that infeasible actions may be present |
+| `constraint-satisfaction-validator` not run (no feasibility info) | Run dominance on all candidates, add warning that infeasible actions may be present |
 
 ---
 
@@ -222,7 +223,7 @@ Step 2 — get_entity_by_number(number="20.16")
 → Retrieved: eq. 20.16 — α dominated by Γ iff max δ < 0
 → Warehouse translation: A dominates B iff u_A[k] ≥ u_B[k] ∀k AND ∃k: u_A[k] > u_B[k]
 
-Step 3 — Upstream utility_breakdown from SKILL-PU-01:
+Step 3 — Upstream utility_breakdown from `multi-attribute-utility-scorer`:
 
     Action A: {u_fill=0.92, u_penalty=0.55, u_lt=1.00, u_sla=1.00}  feasibility=FEASIBLE
     Action B: {u_fill=0.70, u_penalty=0.40, u_lt=0.60, u_sla=0.75}  feasibility=FEASIBLE
@@ -281,7 +282,7 @@ Step 6 — Result:
 
 Action B is eliminated — strictly dominated by A on all four dimensions.
 Action D was already infeasible.
-Remaining frontier: A, C, E — pass these to SKILL-DS-01 for final ranking.
+Remaining frontier: A, C, E — pass these to `expected-utility-action-ranker` for final ranking.
 Note: C is near-dominated by A (advisory). If the penalty attribute weight
 is increased, C would be eliminated entirely.
 ```
@@ -290,9 +291,9 @@ is increased, C would be eliminated entirely.
 
 ## Feeds Into
 
-- `SKILL-DS-01` — receives `pareto_frontier` as its candidate set instead of
+- `expected-utility-action-ranker` — receives `pareto_frontier` as its candidate set instead of
   the full unfiltered list; `dominated_actions` are excluded from ranking
-- `SKILL-MD-01` — `frontier_size` feeds into decision confidence:
+- `decision-confidence-estimator` — `frontier_size` feeds into decision confidence:
   a frontier of 1 → HIGH confidence; frontier of 4+ → lower margin signal
-- `SKILL-PU-02` — if `frontier_size > 2` and scores are close, VOI
+- `value-of-information` — if `frontier_size > 2` and scores are close, VOI
   recalculation may be warranted before committing to the top action

--- a/services/agent-service/skills/ds03_threshold_trigger/SKILL.md
+++ b/services/agent-service/skills/ds03_threshold_trigger/SKILL.md
@@ -3,10 +3,11 @@ name: threshold-based-trigger-decision
 description: "Evaluates the current inventory state against a hierarchy of threshold conditions and returns a typed trigger event — STOCKOUT_IMMINENT, REORDER_TRIGGER, PIPELINE_RISK, or NORMAL — with a recommended action type. Use as the entry-point classifier before deeper decision logic; the trigger event constrains the action space for all downstream skills. Questions like 'Do we need to act on SKU-X right now?', 'Is the inventory level critical?', 'What kind of event is this — reorder or emergency?'"
 version: "1.0"
 tags: [threshold, trigger, inventory, stockout, reorder, policy, safety-stock]
-dependencies: [SKILL-IA-01]
+dependencies:
+  - bayesian-sensor-belief-updater
 ---
 
-# SKILL-DS-03 · Threshold-Based Trigger Decision
+# Threshold-Based Trigger Decision
 
 ## When to Use This Skill
 
@@ -42,7 +43,7 @@ when the state space is one-dimensional and the reward is monotone.
 Four threshold regions partition the state space into four trigger events:
 
 ```
-State s = available_qty (posterior mean from SKILL-IA-01)
+State s = available_qty (posterior mean from `bayesian-sensor-belief-updater`)
 
 s < safety_stock  AND  days_of_cover < 3   →  STOCKOUT_IMMINENT   (CRITICAL)
 s < safety_stock  OR   days_of_cover < 7   →  REORDER_TRIGGER     (HIGH)
@@ -90,16 +91,16 @@ get_entity_by_number(number="7.11")
 
 ---
 
-### Step 3: Get posterior inventory level from SKILL-IA-01
+### Step 3: Get posterior inventory level from `bayesian-sensor-belief-updater`
 
-Requires `posterior_mean` (μ) from `SKILL-IA-01 · Bayesian Sensor Belief Updater`.
+Requires `posterior_mean` (μ) from `bayesian-sensor-belief-updater`.
 This is the best current estimate of true on-hand quantity.
 
 ```
-available_qty = posterior_mean   # from SKILL-IA-01
+available_qty = posterior_mean   # from bayesian-sensor-belief-updater
 ```
 
-If `SKILL-IA-01` was not run, fall back to raw `observed_qty` from the
+If `bayesian-sensor-belief-updater` was not run, fall back to raw `observed_qty` from the
 observed-snapshot endpoint (less reliable):
 
 ```
@@ -212,7 +213,7 @@ else:
 |---|---|
 | `trigger_event` | `STOCKOUT_IMMINENT` / `REORDER_TRIGGER` / `PIPELINE_RISK` / `NORMAL` |
 | `severity` | `CRITICAL` / `HIGH` / `MEDIUM` / `LOW` |
-| `available_qty` | Posterior mean inventory (from SKILL-IA-01 or observed_qty) |
+| `available_qty` | Posterior mean inventory (from `bayesian-sensor-belief-updater` or observed_qty) |
 | `safety_stock` | Threshold used for comparison |
 | `daily_demand` | 30-day average daily demand rate |
 | `days_of_cover` | `available_qty / daily_demand` |
@@ -220,7 +221,7 @@ else:
 | `effective_coverage` | `(available_qty + pipeline_qty) / daily_demand` |
 | `days_to_next_arrival` | Days until next PO expected (if available) |
 | `recommended_action_type` | `EMERGENCY_ORDER` / `PLACE_ORDER` / `EXPEDITE_OR_MONITOR` / `MONITOR` |
-| `ia01_used` | `true` if SKILL-IA-01 posterior was used, `false` if raw observed_qty |
+| `ia01_used` | `true` if `bayesian-sensor-belief-updater` posterior was used, `false` if raw observed_qty |
 
 ---
 
@@ -228,7 +229,7 @@ else:
 
 | Situation | Behaviour |
 |---|---|
-| `SKILL-IA-01` not run, no observed snapshot | Return `trigger_event=NORMAL`, `data_gap_flag=True`, escalate |
+| `bayesian-sensor-belief-updater` not run, no observed snapshot | Return `trigger_event=NORMAL`, `data_gap_flag=True`, escalate |
 | `daily_demand = 0` (no recent moves) | Set `days_of_cover = ∞`, skip cover thresholds, classify by qty vs safety_stock only |
 | Pipeline endpoint unavailable | Set `pipeline_qty = 0`, `effective_cover = days_of_cover`, add warning |
 | `quality_status` is `quarantine` or `damaged` | Override: treat `available_qty = 0` for threshold purposes, add `quality_hold_flag=True` |
@@ -258,7 +259,7 @@ Step 2 — get_entity_by_number(number="7.11")
 → Confirmed: threshold conditions partition the state into regions where
   each action is dominant — tractable approximation to full DP greedy policy
 
-Step 3 — SKILL-IA-01 result:
+Step 3 — `bayesian-sensor-belief-updater` result:
     posterior_mean = 142.0 units
     available_qty  = 142.0   (ia01_used = true)
 
@@ -309,11 +310,11 @@ Recommended action: PLACE_ORDER with expedite option if lead time allows.
 
 ## Feeds Into
 
-- `SKILL-MD-02` — `STOCKOUT_IMMINENT` bypasses deferral controller entirely;
+- `decision-deferral-controller` — `STOCKOUT_IMMINENT` bypasses deferral controller entirely;
   deferral is never permitted when trigger is CRITICAL
-- `SKILL-DS-01` — `trigger_event` constrains the action space:
+- `expected-utility-action-ranker` — `trigger_event` constrains the action space:
   `STOCKOUT_IMMINENT` restricts candidates to `EMERGENCY_ORDER` actions only
-- `SKILL-MD-01` — `severity` contributes to composite confidence score;
+- `decision-confidence-estimator` — `severity` contributes to composite confidence score;
   `CRITICAL` overrides normal confidence thresholds
-- `SKILL-PU-01` — `days_of_cover` feeds `u_fill` calculation as a proxy
+- `multi-attribute-utility-scorer` — `days_of_cover` feeds `u_fill` calculation as a proxy
   for forward fill risk when order line qty is unavailable

--- a/services/agent-service/skills/ia01_sensor_belief_updater/SKILL.md
+++ b/services/agent-service/skills/ia01_sensor_belief_updater/SKILL.md
@@ -6,7 +6,7 @@ tags: [inventory, belief-update, sensor, uncertainty, bayesian]
 dependencies: []
 ---
 
-# SKILL-IA-01 · Bayesian Sensor Belief Updater
+# Bayesian Sensor Belief Updater
 
 ## When to Use This Skill
 
@@ -153,7 +153,7 @@ posterior_mean = max(0.0, posterior_mean)    # inventory cannot be negative
 ```
 <thinking>
 Before committing stock, I need to verify the true inventory level —
-the raw sensor reading may not be reliable. I'll run SKILL-IA-01.
+the raw sensor reading may not be reliable. I'll run `bayesian-sensor-belief-updater`.
 </thinking>
 
 Step 1 — search_knowledge_base("Kalman filter belief update posterior mean...")
@@ -188,6 +188,6 @@ before committing given moderate confidence (0.61).
 
 ## Feeds Into
 
-- `SKILL-RE-01` — uses `posterior_mean`, `posterior_std` to compute uncertainty index
-- `SKILL-MD-01` — uses `effective_confidence` in overall decision confidence
-- `SKILL-MD-03` — compares posteriors across devices to resolve conflicts
+- `inventory-uncertainty-quantifier` — uses `posterior_mean`, `posterior_std` to compute uncertainty index
+- `decision-confidence-estimator` — uses `effective_confidence` in overall decision confidence
+- `signal-conflict-resolver` — compares posteriors across devices to resolve conflicts

--- a/services/agent-service/skills/ia02_supplier_reliability_aggregator/SKILL.md
+++ b/services/agent-service/skills/ia02_supplier_reliability_aggregator/SKILL.md
@@ -6,7 +6,7 @@ tags: [supplier, reliability, bayesian, procurement, risk]
 dependencies: []
 ---
 
-# SKILL-IA-02 · Supplier Reliability Evidence Aggregator
+# Supplier Reliability Evidence Aggregator
 
 ## When to Use This Skill
 
@@ -245,6 +245,6 @@ penalty clauses given the 63% conservative lower bound.
 
 ## Feeds Into
 
-- `SKILL-RE-02` — uses `posterior_mean_reliability` to inflate lead-time variance
-- `SKILL-PU-01` — uses `posterior_mean_reliability` as `u_sla` input for utility scoring
-- `SKILL-DS-01` — used in tie-breaking when two suppliers have equal utility scores
+- `leadtime-risk-estimator` — uses `posterior_mean_reliability` to inflate lead-time variance
+- `multi-attribute-utility-scorer` — uses `posterior_mean_reliability` as `u_sla` input for utility scoring
+- `expected-utility-action-ranker` — used in tie-breaking when two suppliers have equal utility scores

--- a/services/agent-service/skills/ia03_signal_reliability_estimator/SKILL.md
+++ b/services/agent-service/skills/ia03_signal_reliability_estimator/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: signal-reliability-estimator
-description: "Classifies the reliability of each sensor device contributing to inventory observations by combining device health metrics into a single reliability score. Use before trusting any sensor reading, before running SKILL-IA-01, or when diagnosing why inventory data looks suspicious. Questions like 'Can I trust the sensors in Warehouse B?', 'Which devices are degraded right now?', 'Why does the inventory data look noisy today?'"
+description: "Classifies the reliability of each sensor device contributing to inventory observations by combining device health metrics into a single reliability score. Use before trusting any sensor reading, before running `bayesian-sensor-belief-updater`, or when diagnosing why inventory data looks suspicious. Questions like 'Can I trust the sensors in Warehouse B?', 'Which devices are degraded right now?', 'Why does the inventory data look noisy today?'"
 version: "1.0"
 tags: [sensor, reliability, device-health, anomaly, naive-bayes]
 dependencies: []
 ---
 
-# SKILL-IA-03 · Signal Reliability Estimator
+# Signal Reliability Estimator
 
 ## When to Use This Skill
 
@@ -14,7 +14,7 @@ Activate this skill when the user asks about:
 - Whether sensor data from a specific warehouse or location can be trusted
 - Which devices are currently degraded or anomalous
 - Why inventory readings look inconsistent or noisy
-- As a prerequisite check before running `SKILL-IA-01` or `SKILL-MD-03`
+- As a prerequisite check before running `bayesian-sensor-belief-updater` or `signal-conflict-resolver`
 - Questions like *"Are our sensors in Warehouse B reliable right now?"*
   or *"Which devices should I not trust today?"*
 
@@ -222,13 +222,13 @@ Result:
 Warehouse B has 1 unreliable device (D-102 — calibration drift, bias=4.5).
 Readings from D-102's locations should not be trusted without bias correction.
 Recommend: exclude D-102 observations from the order commit calculation,
-or run SKILL-IA-01 with reported_noise_sigma override for affected locations.
+or run `bayesian-sensor-belief-updater` with reported_noise_sigma override for affected locations.
 ```
 
 ---
 
 ## Feeds Into
 
-- `SKILL-IA-01` — uses `reliability_class` to decide whether to trust raw observations
-- `SKILL-MD-01` — applies `-0.15` confidence penalty per LOW-reliability device found
-- `SKILL-MD-03` — uses `reliability_score` per device to weight-average conflicting readings
+- `bayesian-sensor-belief-updater` — uses `reliability_class` to decide whether to trust raw observations
+- `decision-confidence-estimator` — applies `-0.15` confidence penalty per LOW-reliability device found
+- `signal-conflict-resolver` — uses `reliability_score` per device to weight-average conflicting readings

--- a/services/agent-service/skills/md01_confidence_estimator/SKILL.md
+++ b/services/agent-service/skills/md01_confidence_estimator/SKILL.md
@@ -3,10 +3,14 @@ name: decision-confidence-estimator
 description: "Computes a composite confidence score for the current decision by aggregating four signals — sensor reliability, inventory regime stability, inventory uncertainty, and action margin — into a single scalar. Returns a confidence class and a recommended next step (EXECUTE / EXECUTE_WITH_FLAG / DEFER / ESCALATE). Use as the final meta-decision gate before executing any high-stakes action. Questions like 'How confident are we in this decision?', 'Should we execute or wait?', 'Is the data good enough to act on?'"
 version: "1.0"
 tags: [confidence, meta-decision, Bayesian, posterior, uncertainty, composite]
-dependencies: [SKILL-IA-03, SKILL-RE-01, SKILL-RE-03, SKILL-DS-01]
+dependencies:
+  - signal-reliability-estimator
+  - inventory-uncertainty-quantifier
+  - inventory-flow-regime-detector
+  - expected-utility-action-ranker
 ---
 
-# SKILL-MD-01 · Decision Confidence Estimator
+# Decision Confidence Estimator
 
 ## When to Use This Skill
 
@@ -14,7 +18,7 @@ Activate this skill when the user asks about:
 - How confident the agent is before executing a recommended action
 - Whether the current data quality is sufficient to act
 - Whether a decision should be executed, flagged, deferred, or escalated
-- As the final gate in any decision pipeline after SKILL-DS-01 has ranked actions
+- As the final gate in any decision pipeline after `expected-utility-action-ranker` has ranked actions
 - Questions like *"Are we confident enough to commit this order?"*
   or *"Should we execute now or wait for better sensor data?"*
 
@@ -96,14 +100,14 @@ get_entity_by_number(number="14.6")
 - This is the operational inverse of confidence: high relative SE → act with
   caution; low relative SE → sufficient precision to execute
 - Warehouse mapping: `c_uncertainty = 1 − uncertainty_index` is the
-  complement of the relative uncertainty quantified by SKILL-RE-01
+  complement of the relative uncertainty quantified by `inventory-uncertainty-quantifier`
 
 ---
 
-### Step 3: Get sensor reliability component from SKILL-IA-03
+### Step 3: Get sensor reliability component from `signal-reliability-estimator`
 
 Requires `reliability_score` per device and `low_reliability_device_count`
-from `SKILL-IA-03 · Signal Reliability Estimator`.
+from `signal-reliability-estimator`.
 
 ```
 # c_sensor: mean reliability across all active devices ∈ [0,1]
@@ -115,13 +119,13 @@ low_rel_count = count(d for d in devices if d.reliability_class == LOW)
 penalty_sensor = 0.15 × low_rel_count
 ```
 
-If SKILL-IA-03 not run: `c_sensor = 0.5` (neutral), `penalty_sensor = 0`.
+If `signal-reliability-estimator` not run: `c_sensor = 0.5` (neutral), `penalty_sensor = 0`.
 
 ---
 
-### Step 4: Get regime stability component from SKILL-RE-03
+### Step 4: Get regime stability component from `inventory-flow-regime-detector`
 
-Requires `regime_label` from `SKILL-RE-03 · Inventory Flow Regime Detector`.
+Requires `regime_label` from `inventory-flow-regime-detector`.
 
 ```
 # c_regime: stability of the inventory flow regime ∈ [0,1]
@@ -134,13 +138,13 @@ c_regime = {
 }[regime_label]
 ```
 
-If SKILL-RE-03 not run: `c_regime = 0.8` (assume stable, add warning).
+If `inventory-flow-regime-detector` not run: `c_regime = 0.8` (assume stable, add warning).
 
 ---
 
-### Step 5: Get inventory uncertainty component from SKILL-RE-01
+### Step 5: Get inventory uncertainty component from `inventory-uncertainty-quantifier`
 
-Requires `uncertainty_index` from `SKILL-RE-01 · Inventory Uncertainty Quantifier`.
+Requires `uncertainty_index` from `inventory-uncertainty-quantifier`.
 
 ```
 # c_uncertainty: complement of uncertainty index ∈ [0,1]
@@ -148,13 +152,13 @@ Requires `uncertainty_index` from `SKILL-RE-01 · Inventory Uncertainty Quantifi
 c_uncertainty = 1.0 - uncertainty_index
 ```
 
-If SKILL-RE-01 not run: `c_uncertainty = 0.5` (neutral), add warning.
+If `inventory-uncertainty-quantifier` not run: `c_uncertainty = 0.5` (neutral), add warning.
 
 ---
 
-### Step 6: Get action margin component from SKILL-DS-01
+### Step 6: Get action margin component from `expected-utility-action-ranker`
 
-Requires `margin` and `decision_confidence` from `SKILL-DS-01 · Expected-Utility Action Ranker`.
+Requires `margin` and `decision_confidence` from `expected-utility-action-ranker`.
 
 ```
 # c_margin: normalised advantage margin ∈ [0,1]
@@ -167,7 +171,7 @@ if decision_confidence_ds01 == TIE:
     c_margin = 0.0
 ```
 
-If SKILL-DS-01 not run: `c_margin = 0.5` (neutral), add warning.
+If `expected-utility-action-ranker` not run: `c_margin = 0.5` (neutral), add warning.
 
 ---
 
@@ -263,7 +267,7 @@ Step 2 — get_entity_by_number(number="4.27")
 → Retrieved: relative SE = σ̂/(μ̂√n)  (eq. 14.6)
   high relative SE → high uncertainty → lower confidence component
 
-Step 3 — SKILL-IA-03 result:
+Step 3 — `signal-reliability-estimator` result:
     device_1: reliability_score=0.82, class=MEDIUM
     device_2: reliability_score=0.91, class=HIGH
     device_3: reliability_score=0.34, class=LOW    ← penalty
@@ -271,15 +275,15 @@ Step 3 — SKILL-IA-03 result:
     low_rel_count = 1
     penalty_sensor = 0.15 × 1 = 0.15
 
-Step 4 — SKILL-RE-03 result:
+Step 4 — `inventory-flow-regime-detector` result:
     regime_label = ELEVATED_ADJUSTMENTS
     c_regime     = 0.6
 
-Step 5 — SKILL-RE-01 result:
+Step 5 — `inventory-uncertainty-quantifier` result:
     uncertainty_index = 0.41  (MODERATE)
     c_uncertainty     = 1 − 0.41 = 0.59
 
-Step 6 — SKILL-DS-01 result:
+Step 6 — `expected-utility-action-ranker` result:
     margin                = 0.13
     decision_confidence   = HIGH  (margin > 0.10)
     c_margin              = min(0.13 / 0.10, 1.0) = 1.0
@@ -313,9 +317,9 @@ cycle for this SKU.
 
 ## Feeds Into
 
-- `SKILL-MD-02` — receives `confidence_class` and `recommended_next_step`
+- `decision-deferral-controller` — receives `confidence_class` and `recommended_next_step`
   to decide whether to defer and how long to wait
 - Executor / human reviewer — `recommended_next_step` is the final output
   that determines whether the pipeline commits the action or pauses
-- `SKILL-PU-02` — if `DEFER`, re-evaluates VOI to determine whether
+- `value-of-information` — if `DEFER`, re-evaluates VOI to determine whether
   waiting is worth the delay cost

--- a/services/agent-service/skills/md02_deferral_controller/SKILL.md
+++ b/services/agent-service/skills/md02_deferral_controller/SKILL.md
@@ -3,10 +3,14 @@ name: decision-deferral-controller
 description: "Decides whether to defer the current decision — waiting for better data — or commit now. Uses VOI and decision confidence to determine if exploration still pays off, then computes an optimal wait duration. Enforces hard limits: STOCKOUT_IMMINENT bypasses deferral entirely; maximum 2 deferrals and 48h wait are enforced to prevent indefinite delay. Questions like 'Should we wait for a cycle count before acting?', 'Is it safe to defer this order?', 'How long should we wait before deciding?'"
 version: "1.0"
 tags: [deferral, explore-then-commit, VOI, confidence, stopping-rule, meta-decision]
-dependencies: [SKILL-PU-02, SKILL-MD-01, SKILL-RE-01, SKILL-DS-03]
+dependencies:
+  - value-of-information
+  - decision-confidence-estimator
+  - inventory-uncertainty-quantifier
+  - threshold-based-trigger-decision
 ---
 
-# SKILL-MD-02 · Decision Deferral Controller
+# Decision Deferral Controller
 
 ## When to Use This Skill
 
@@ -14,7 +18,7 @@ Activate this skill when the user asks about:
 - Whether to act now or wait for more/better information
 - How long the agent should delay before committing to a decision
 - Whether the current confidence level justifies deferral
-- As the final meta-decision gate after `SKILL-MD-01` returns `DEFER`
+- As the final meta-decision gate after `decision-confidence-estimator` returns `DEFER`
 - Questions like *"Should we hold off on this order until we recount?"*
   or *"Is it worth waiting 24 hours for a fresh sensor reading?"*
   or *"We've already deferred once — should we defer again?"*
@@ -116,7 +120,7 @@ Before any VOI or confidence calculation, evaluate absolute overrides:
 
 ```
 # Bypass 1 — STOCKOUT_IMMINENT: never defer when inventory is critical
-if trigger_event == STOCKOUT_IMMINENT:   # from SKILL-DS-03
+if trigger_event == STOCKOUT_IMMINENT:   # from `threshold-based-trigger-decision`
     return {
         deferral_decision: CANNOT_DEFER,
         bypass_reason:     STOCKOUT_IMMINENT,
@@ -137,9 +141,9 @@ if deferral_count >= MAX_DEFERRAL_COUNT:   # MAX_DEFERRAL_COUNT = 2
 ### Step 4: Evaluate VOI and confidence gate
 
 Requires from upstream skills:
-- `voi_net` from `SKILL-PU-02`
-- `confidence_class` from `SKILL-MD-01`
-- `uncertainty_index` from `SKILL-RE-01`
+- `voi_net` from `value-of-information`
+- `confidence_class` from `decision-confidence-estimator`
+- `uncertainty_index` from `inventory-uncertainty-quantifier`
 
 ```
 # Two conditions must BOTH hold to justify deferral
@@ -218,7 +222,7 @@ else:
 | `deferrals_remaining` | `MAX_DEFERRAL_COUNT − deferral_count` |
 | `hours_since_last_obs` | Staleness of latest inventory observation |
 | `voi_net_used` | `voi_net` value that drove the decision |
-| `confidence_class_used` | `confidence_class` from SKILL-MD-01 |
+| `confidence_class_used` | `confidence_class` from `decision-confidence-estimator` |
 | `recommended_next_step` | `WAIT_AND_REOBSERVE` / `EXECUTE` / `EXECUTE_WITH_FLAG` |
 
 ---
@@ -227,8 +231,8 @@ else:
 
 | Situation | Behaviour |
 |---|---|
-| `SKILL-PU-02` not run | Treat `voi_net = 0`; skip VOI gate → CANNOT_DEFER unless confidence forces deferral |
-| `SKILL-MD-01` not run | Treat `confidence_class = ADEQUATE`; skip confidence gate → CANNOT_DEFER |
+| `value-of-information` not run | Treat `voi_net = 0`; skip VOI gate → CANNOT_DEFER unless confidence forces deferral |
+| `decision-confidence-estimator` not run | Treat `confidence_class = ADEQUATE`; skip confidence gate → CANNOT_DEFER |
 | `trigger_event` unavailable | Skip bypass check; proceed with VOI+confidence gate only |
 | `last_count_at` unavailable | Use `hours_since_last_obs = 24h` (conservative); τ_optimal unchanged |
 | `uncertainty_index = 0` | `τ_optimal = 0h`; deferral not meaningful → CANNOT_DEFER |
@@ -264,19 +268,19 @@ Step 2 — get_entity_by_number(number="15.2")
   → equivalent to voi_net > 0 AND confidence is LOW
 
 Step 3 — Bypass checks:
-    trigger_event  = REORDER_TRIGGER  (from SKILL-DS-03, not STOCKOUT_IMMINENT)
+    trigger_event  = REORDER_TRIGGER  (from `threshold-based-trigger-decision`, not STOCKOUT_IMMINENT)
     deferral_count = 1  (already deferred once)
     MAX_DEFERRAL_COUNT = 2
     → Neither bypass fires; 1 deferral remaining
 
 Step 4 — VOI and confidence gate:
-    voi_net          = 0.03   (from SKILL-PU-02)  → voi_justifies_wait = True
-    confidence_class = LOW_CONFIDENCE  (from SKILL-MD-01, C=0.38)
+    voi_net          = 0.03   (from `value-of-information`)  → voi_justifies_wait = True
+    confidence_class = LOW_CONFIDENCE  (from `decision-confidence-estimator`, C=0.38)
     → confidence_low_enough = True
     → should_defer = True ✓
 
 Step 5 — Optimal wait duration:
-    uncertainty_index   = 0.61  (from SKILL-RE-01)
+    uncertainty_index   = 0.61  (from `inventory-uncertainty-quantifier`)
     τ_optimal           = 0.61 × 48 = 29.3h
     → rounded to 6h cycle: ceil(29.3/6) × 6 = 30h
 
@@ -310,9 +314,9 @@ be returned and the agent must commit regardless of confidence.
 
 - **Executor / orchestrator** — `deferral_decision` is the terminal output;
   `DEFER` suspends execution for `optimal_wait_hours`, then restarts pipeline
-- `SKILL-DS-03` — after the wait, re-run DS-03 to check if `trigger_event`
+- `threshold-based-trigger-decision` — after the wait, re-run it to check if `trigger_event`
   has escalated to STOCKOUT_IMMINENT (would bypass deferral on next call)
-- `SKILL-MD-01` — after the wait, re-run MD-01; rising confidence should
+- `decision-confidence-estimator` — after the wait, re-run it; rising confidence should
   eventually return ADEQUATE or CONFIDENT, allowing EXECUTE
-- `SKILL-PU-02` — after the wait, re-run PU-02; if new observation was
+- `value-of-information` — after the wait, re-run it; if new observation was
   gathered, `voi_net` should drop to ≤ 0, unlocking commitment

--- a/services/agent-service/skills/md03_conflict_resolver/SKILL.md
+++ b/services/agent-service/skills/md03_conflict_resolver/SKILL.md
@@ -3,10 +3,14 @@ name: signal-conflict-resolver
 description: "Detects and resolves conflicts between signals before a decision is committed. Handles three conflict types: Type A (quantity conflict — two sensors report values more than 2σ apart), Type B (action conflict — two ranked pipelines recommend incompatible actions), Type C (model conflict — upstream belief and regime are inconsistent). Returns a resolved quantity or resolved action, the resolution method used, a downgraded confidence delta, and an escalation flag. Use whenever multiple independent signals feed the same decision variable. Questions like 'Sensor A says 140, sensor B says 320 — which do we trust?', 'One pipeline says reorder, another says hold — now what?', 'The signals are contradicting each other.'"
 version: "1.0"
 tags: [conflict, sensor-fusion, belief-propagation, particle-injection, resolution, meta-decision]
-dependencies: [SKILL-IA-01, SKILL-IA-03, SKILL-DS-01, SKILL-RE-03]
+dependencies:
+  - bayesian-sensor-belief-updater
+  - signal-reliability-estimator
+  - expected-utility-action-ranker
+  - inventory-flow-regime-detector
 ---
 
-# SKILL-MD-03 · Signal Conflict Resolver
+# Signal Conflict Resolver
 
 ## When to Use This Skill
 
@@ -35,7 +39,7 @@ P(c | o₁:ₙ) ∝ P(c) ∏ᵢ P(oᵢ | c)     (eq. 3.4 + 3.8)
 ```
 
 Each sensor's reading is one observation. Reliability score `rᵢ` from
-SKILL-IA-03 plays the role of `P(oᵢ | c)` — higher reliability → higher
+`signal-reliability-estimator` plays the role of `P(oᵢ | c)` — higher reliability → higher
 weight in the posterior. The resolved quantity is the reliability-weighted
 mean across non-outlier sensors, normalised by their total weight.
 
@@ -132,10 +136,10 @@ get_entity_by_number(number="19.29")
 ### Step 3: Detect conflict type
 
 Collect all competing signal values. Sources:
-- `SKILL-IA-01` outputs: one `posterior_mean` + `posterior_std` per sensor/pipeline
-- `SKILL-IA-03` outputs: `reliability_score` per device
-- `SKILL-DS-01` outputs: `top_action_id` + `trigger_event` per pipeline
-- `SKILL-RE-03` outputs: `baseline_mean`, `baseline_std` (regime model)
+- `bayesian-sensor-belief-updater` outputs: one `posterior_mean` + `posterior_std` per sensor/pipeline
+- `signal-reliability-estimator` outputs: `reliability_score` per device
+- `expected-utility-action-ranker` outputs: `top_action_id` + `trigger_event` per pipeline
+- `inventory-flow-regime-detector` outputs: `baseline_mean`, `baseline_std` (regime model)
 
 #### Type A — Quantity conflict
 
@@ -174,8 +178,8 @@ type_B_detected = any(
 
 ```
 # After Type A resolution, check resolved quantity against regime model
-# (requires SKILL-RE-03 baseline_mean and baseline_std)
-μ_regime  = baseline_mean   # from SKILL-RE-03
+# (requires inventory-flow-regime-detector baseline_mean and baseline_std)
+μ_regime  = baseline_mean   # from inventory-flow-regime-detector
 σ_regime  = baseline_std
 
 type_C_detected = (
@@ -219,7 +223,7 @@ resolution_method_A = SINGLE_SOURCE_FALLBACK
 #### Resolve Type B — Priority hierarchy
 
 Apply a strict priority order grounded in STOCKOUT_IMMINENT bypass rule
-from SKILL-MD-02 (critical states always override normal states):
+from `decision-deferral-controller` (critical states always override normal states):
 
 ```
 PRIORITY = {
@@ -231,7 +235,7 @@ PRIORITY = {
 
 resolved_action = pipeline with highest PRIORITY[trigger_event]
 
-# Tiebreak: higher action_utility_score from SKILL-DS-01
+# Tiebreak: higher action_utility_score from expected-utility-action-ranker
 if tie: resolved_action = pipeline with higher action_utility_score
 
 resolution_method_B = PRIORITY_HIERARCHY
@@ -255,7 +259,7 @@ resolution_method_C = BELIEF_RESET_ESCALATE
 ### Step 5: Compute confidence downgrade
 
 Each detected conflict type reduces decision confidence by a fixed delta,
-applied additively to the `decision_confidence_score` from SKILL-MD-01:
+applied additively to the `decision_confidence_score` from `decision-confidence-estimator`:
 
 ```
 confidence_delta = 0.0
@@ -289,7 +293,7 @@ if type_C_detected:
 | `resolved_action` | `top_action_id` after Type B resolution |
 | `resolution_method` | Per type: `RELIABILITY_WEIGHTED_MEAN` / `SINGLE_SOURCE_FALLBACK` / `PRIORITY_HIERARCHY` / `BELIEF_RESET_ESCALATE` |
 | `outlier_sensor_id` | Device ID of the outlier sensor (Type A only) |
-| `confidence_delta` | Negative adjustment to apply to SKILL-MD-01 score |
+| `confidence_delta` | Negative adjustment to apply to `decision-confidence-estimator` score |
 | `escalation_required` | `True` if Type C detected (belief reset triggered) |
 
 ---
@@ -300,8 +304,8 @@ if type_C_detected:
 |---|---|
 | Only one sensor available | `type_A_detected=False`; no conflict possible; pass through as-is |
 | All sensors have `reliability_score < 0.2` | No reliable source to weight; `resolution_method=SINGLE_SOURCE_FALLBACK` using highest-reliability sensor; add warning |
-| `SKILL-RE-03` not run (no regime baseline) | Skip Type C check; `type_C_detected=False`; add `regime_check_skipped=True` |
-| `SKILL-DS-01` not run (no action scores) | Type B tiebreak falls back to trigger_event priority only |
+| `inventory-flow-regime-detector` not run (no regime baseline) | Skip Type C check; `type_C_detected=False`; add `regime_check_skipped=True` |
+| `expected-utility-action-ranker` not run (no action scores) | Type B tiebreak falls back to trigger_event priority only |
 | Type A and Type B both detected | Resolve independently; combine `confidence_delta`; use resolved_quantity for Type B re-evaluation if needed |
 | All sensor weights sum to zero | Treat as belief collapse; set `escalation_required=True`, return `resolution_method=BELIEF_RESET_ESCALATE` |
 
@@ -365,7 +369,7 @@ Step 4 — Resolve Type A:
       = sqrt(7023.5) = 83.8 units
 
     Check Type C vs regime:
-    μ_regime = 210, σ_regime = 35  (from SKILL-RE-03)
+    μ_regime = 210, σ_regime = 35  (from `inventory-flow-regime-detector`)
     |197.2 − 210| = 12.8 < 3 × 35 = 105  → Type C NOT detected
 
 Step 5 — Confidence downgrade:
@@ -395,11 +399,11 @@ Schedule a physical cycle count to determine ground truth.
 
 ## Feeds Into
 
-- `SKILL-MD-01` — apply `confidence_delta` to `decision_confidence_score`
+- `decision-confidence-estimator` — apply `confidence_delta` to `decision_confidence_score`
   before classifying confidence class; may push ADEQUATE → LOW_CONFIDENCE
-- `SKILL-IA-01` — `resolved_quantity` replaces the conflicted posterior mean
+- `bayesian-sensor-belief-updater` — `resolved_quantity` replaces the conflicted posterior mean
   as the canonical inventory estimate for all downstream calculations
-- `SKILL-MD-02` — `escalation_required=True` (Type C) is equivalent to
+- `decision-deferral-controller` — `escalation_required=True` (Type C) is equivalent to
   `INSUFFICIENT` confidence; deferral controller must trigger ESCALATE
-- `SKILL-DS-01` — after Type B resolution, re-run ranking with only the
+- `expected-utility-action-ranker` — after Type B resolution, re-run ranking with only the
   `resolved_action`'s pipeline to confirm the utility scores are consistent

--- a/services/agent-service/skills/pu01_utility_scorer/SKILL.md
+++ b/services/agent-service/skills/pu01_utility_scorer/SKILL.md
@@ -3,10 +3,12 @@ name: multi-attribute-utility-scorer
 description: "Scores candidate actions (replenishment orders, allocations, supplier selections) by computing a weighted multi-attribute utility that combines fill rate, penalty exposure, lead-time risk, and SLA priority into a single comparable scalar. Use before ranking actions or selecting the best option. Questions like 'Which replenishment action is best overall?', 'How good is this allocation decision?', 'Score these three supplier options.'"
 version: "1.0"
 tags: [utility, decision, multi-attribute, expected-utility, MEU, ranking]
-dependencies: [SKILL-IA-02, SKILL-RE-02]
+dependencies:
+  - supplier-reliability-aggregator
+  - leadtime-risk-estimator
 ---
 
-# SKILL-PU-01 · Multi-Attribute Utility Scorer
+# Multi-Attribute Utility Scorer
 
 ## When to Use This Skill
 
@@ -14,7 +16,7 @@ Activate this skill when the user asks about:
 - Which of several candidate actions is the best overall choice
 - Scoring a replenishment order, allocation, or supplier selection
 - Combining multiple competing objectives (fill rate, penalties, lead time, SLA) into one score
-- As input to `SKILL-DS-01` before final action ranking
+- As input to `expected-utility-action-ranker` before final action ranking
 - Questions like *"Which supplier option scores best given our priorities?"*
   or *"How good is this replenishment plan compared to the alternatives?"*
 
@@ -112,11 +114,11 @@ u_fill    = fill_rate                          # 0 = no fill, 1 = full fill
 penalty_exposure = service_level_penalty × max(qty_ordered - qty_allocated, 0)
 u_penalty = 1 / (1 + penalty_exposure / 1000)  # normalised: high penalty → low utility
 
-# u_lt — lead-time risk utility (from SKILL-RE-02 risk_class)
+# u_lt — lead-time risk utility (from `leadtime-risk-estimator` risk_class)
 u_lt = 1.0   if risk_class = ACCEPTABLE
        0.6   if risk_class = ELEVATED
        0.2   if risk_class = CRITICAL
-       1.0   if SKILL-RE-02 not available (no lead-time uncertainty)
+       1.0   if `leadtime-risk-estimator` not available (no lead-time uncertainty)
 
 # u_sla — SLA priority utility (direct normalisation of sla_priority)
 # sla_priority is typically 1 (highest) to 5 (lowest)
@@ -154,7 +156,7 @@ dominant_driver = attribute with highest weighted contribution:
 
 | Situation | Behaviour |
 |---|---|
-| `SKILL-RE-02` not run | `u_lt=1.0`, add warning that lead-time risk is not accounted for |
+| `leadtime-risk-estimator` not run | `u_lt=1.0`, add warning that lead-time risk is not accounted for |
 | `qty_ordered = 0` | `u_fill=1.0` (trivially satisfied), add warning |
 | `service_level_penalty` missing | `u_penalty=0.5` (neutral), add warning |
 | `sla_priority` missing | `u_sla=0.5` (neutral), add warning |
@@ -188,7 +190,7 @@ Step 3 — GET /purchase-orders for three candidate POs:
     Action B: qty_ordered=500, qty_allocated=350, sla_priority=2, service_level_penalty=20
     Action C: qty_ordered=300, qty_allocated=300, sla_priority=3, service_level_penalty=5
 
-Step 4 — SKILL-RE-02 results: A=ELEVATED, B=ACCEPTABLE, C=ACCEPTABLE
+Step 4 — `leadtime-risk-estimator` results: A=ELEVATED, B=ACCEPTABLE, C=ACCEPTABLE
 
 Compute utilities:
     Action A: u_fill=0.96, u_penalty=1/(1+400)=0.002, u_lt=0.6,  u_sla=1.0
@@ -210,14 +212,14 @@ Result:
 Action C scores highest despite smaller quantity — full fill with zero
 penalty exposure and low lead-time risk outweighs Action A's higher fill count.
 Recommend Action C. Note: if volume is a hard requirement, escalate to
-SKILL-PU-03 to check capacity constraints before committing.
+`constraint-satisfaction-validator` to check capacity constraints before committing.
 ```
 
 ---
 
 ## Feeds Into
 
-- `SKILL-DS-01` — uses `action_utility_score` to rank and select best action
-- `SKILL-DS-02` — uses `utility_breakdown` for stochastic dominance filtering
-- `SKILL-PU-02` — uses best `action_utility_score` as baseline EU for VOI calculation
-- `SKILL-MD-01` — uses scores spread to compute decision margin
+- `expected-utility-action-ranker` — uses `action_utility_score` to rank and select best action
+- `stochastic-dominance-filter` — uses `utility_breakdown` for stochastic dominance filtering
+- `value-of-information` — uses best `action_utility_score` as baseline EU for VOI calculation
+- `decision-confidence-estimator` — uses scores spread to compute decision margin

--- a/services/agent-service/skills/pu02_value_of_information/SKILL.md
+++ b/services/agent-service/skills/pu02_value_of_information/SKILL.md
@@ -3,10 +3,12 @@ name: value-of-information
 description: "Computes whether it is worth gathering more information (e.g. triggering a cycle count) before acting, or whether the agent should act now on current beliefs. Uses the VOI framework to compare expected utility with vs without additional observation, net of the cost of counting. Use before high-stakes decisions under HIGH uncertainty. Questions like 'Should we count stock before committing this order?', 'Is it worth waiting for more data?', 'Does gathering more information change our decision?'"
 version: "1.0"
 tags: [VOI, value-of-information, decision, uncertainty, count, defer]
-dependencies: [SKILL-PU-01, SKILL-RE-01]
+dependencies:
+  - multi-attribute-utility-scorer
+  - inventory-uncertainty-quantifier
 ---
 
-# SKILL-PU-02 · Trade-Off Evaluator (Value of Information)
+# Trade-Off Evaluator (Value of Information)
 
 ## When to Use This Skill
 
@@ -77,20 +79,20 @@ get_entity_by_number(number="6.9")
 
 ---
 
-### Step 3: Get current best EU from SKILL-PU-01
+### Step 3: Get current best EU from `multi-attribute-utility-scorer`
 
-Requires `action_utility_score` (best scoring action) from `SKILL-PU-01`.
+Requires `action_utility_score` (best scoring action) from `multi-attribute-utility-scorer`.
 This is `EU*(o)` — the utility of the best action given current information.
 
-If `SKILL-PU-01` was not run, use `uncertainty_index` from `SKILL-RE-01`
+If `multi-attribute-utility-scorer` was not run, use `uncertainty_index` from `inventory-uncertainty-quantifier`
 as a proxy: high uncertainty → assume current EU is suboptimal.
 
 ---
 
-### Step 4: Get uncertainty index from SKILL-RE-01
+### Step 4: Get uncertainty index from `inventory-uncertainty-quantifier`
 
 Requires `uncertainty_index` and `posterior_mean (μ)`, `posterior_std (σ)`
-from `SKILL-RE-01` / `SKILL-IA-01`.
+from `inventory-uncertainty-quantifier` / `bayesian-sensor-belief-updater`.
 
 These parameterise `P(o' | o)` — the predictive distribution over what
 a cycle count would reveal:
@@ -110,7 +112,7 @@ P(qty_low  | o) = 0.5
 For each simulated observation `o'` ∈ {qty_high, qty_low}:
 
 Re-score the best action using the updated fill rate and penalty exposure
-(same formula as `SKILL-PU-01 Step 4`) with `qty_allocated = min(qty_ordered, o')`:
+(same formula as `multi-attribute-utility-scorer` Step 4) with `qty_allocated = min(qty_ordered, o')`:
 
 ```
 EU*(o, qty_high) = utility score if true qty = μ + 2σ
@@ -180,7 +182,7 @@ if next shipment arrives within 2 days, waiting may be free (no count needed).
 
 | Situation | Behaviour |
 |---|---|
-| `SKILL-PU-01` not run | Use `uncertainty_index` as proxy; `voi_gross` is approximate |
+| `multi-attribute-utility-scorer` not run | Use `uncertainty_index` as proxy; `voi_gross` is approximate |
 | `uncertainty_index = 0` (CERTAIN) | `VOI_gross = 0`, `recommendation = ACT_NOW` immediately |
 | `posterior_std = 0` | No scenario spread possible, `VOI_gross = 0`, act now |
 | Pipeline endpoint unavailable | Skip enrichment, proceed with count recommendation only |
@@ -204,10 +206,10 @@ Step 1 — search_knowledge_base("value of information expected utility observat
 Step 2 — get_entity_by_number(number="6.9")
 → Confirmed: VOI = 0 if new observation changes no optimal action
 
-Step 3 — SKILL-PU-01 result:
+Step 3 — `multi-attribute-utility-scorer` result:
     EU*(o) = 0.71  (best action: commit 400 units, fill_rate=0.89)
 
-Step 4 — SKILL-RE-01 result:
+Step 4 — `inventory-uncertainty-quantifier` result:
     posterior_mean = 448.0,  posterior_std = 61.0
     uncertainty_index = 0.64  (HIGH)
 
@@ -247,6 +249,6 @@ not 400, to avoid penalty exposure under HIGH uncertainty.
 
 ## Feeds Into
 
-- `SKILL-MD-02` — uses `recommendation` and `voi_net` to decide whether to defer
-- `SKILL-DS-01` — if `GATHER_INFO`, pauses action ranking until new data arrives
-- `SKILL-MD-01` — uses `voi_net` as signal of decision readiness
+- `decision-deferral-controller` — uses `recommendation` and `voi_net` to decide whether to defer
+- `expected-utility-action-ranker` — if `GATHER_INFO`, pauses action ranking until new data arrives
+- `decision-confidence-estimator` — uses `voi_net` as signal of decision readiness

--- a/services/agent-service/skills/pu03_constraint_validator/SKILL.md
+++ b/services/agent-service/skills/pu03_constraint_validator/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: constraint-satisfaction-validator
-description: "Validates whether a proposed warehouse action (replenishment, allocation, transfer) satisfies all hard physical and operational constraints before execution: capacity, quality status, shelf life, and allocation bounds. Blocks INFEASIBLE actions before they reach the utility scorer. Use as a pre-filter before SKILL-PU-01 or before committing any warehouse operation. Questions like 'Can we physically fit this order in Warehouse B?', 'Is this stock eligible for outbound shipment?', 'Will this allocation exceed our committed quantities?'"
+description: "Validates whether a proposed warehouse action (replenishment, allocation, transfer) satisfies all hard physical and operational constraints before execution: capacity, quality status, shelf life, and allocation bounds. Blocks INFEASIBLE actions before they reach the utility scorer. Use as a pre-filter before `multi-attribute-utility-scorer` or before committing any warehouse operation. Questions like 'Can we physically fit this order in Warehouse B?', 'Is this stock eligible for outbound shipment?', 'Will this allocation exceed our committed quantities?'"
 version: "1.0"
 tags: [constraint, feasibility, capacity, quality, allocation, validation]
 dependencies: []
 ---
 
-# SKILL-PU-03 · Constraint Satisfaction Validator
+# Constraint Satisfaction Validator
 
 ## When to Use This Skill
 
@@ -14,7 +14,7 @@ Activate this skill when the user asks about:
 - Whether a proposed action is physically possible given warehouse capacity
 - Whether stock quality status allows outbound shipment
 - Whether an allocation exceeds committed order quantities
-- As a mandatory pre-filter before scoring actions in `SKILL-PU-01`
+- As a mandatory pre-filter before scoring actions in `multi-attribute-utility-scorer`
 - Questions like *"Can Warehouse B physically hold this replenishment order?"*
   or *"Is this stock eligible for the customer shipment?"*
 
@@ -263,7 +263,7 @@ Result:
   remaining_capacity   = 1200 units after action
   quality_status       = good
 
-All constraints satisfied. Action is cleared for utility scoring in SKILL-PU-01.
+All constraints satisfied. Action is cleared for utility scoring in `multi-attribute-utility-scorer`.
 Available quantity (340 units) covers the requested 300 — proceed.
 ```
 
@@ -271,6 +271,6 @@ Available quantity (340 units) covers the requested 300 — proceed.
 
 ## Feeds Into
 
-- `SKILL-DS-01` — `INFEASIBLE` actions are filtered out before ranking
-- `SKILL-PU-01` — `soft_violation_score` can be subtracted from utility score
-- `SKILL-MD-01` — `CONDITIONAL` status adds a confidence penalty
+- `expected-utility-action-ranker` — `INFEASIBLE` actions are filtered out before ranking
+- `multi-attribute-utility-scorer` — `soft_violation_score` can be subtracted from utility score
+- `decision-confidence-estimator` — `CONDITIONAL` status adds a confidence penalty

--- a/services/agent-service/skills/re01_uncertainty_quantifier/SKILL.md
+++ b/services/agent-service/skills/re01_uncertainty_quantifier/SKILL.md
@@ -3,10 +3,11 @@ name: inventory-uncertainty-quantifier
 description: "Converts a posterior belief distribution over inventory quantity into a single interpretable uncertainty index, combining statistical spread (coefficient of variation), information-theoretic entropy, data staleness, and quality status. Use before any high-stakes decision to understand how much to trust the inventory estimate. Questions like 'How confident are we in this stock level?', 'Is this inventory estimate reliable enough to commit?', 'How stale is this data?'"
 version: "1.0"
 tags: [inventory, uncertainty, entropy, belief, POMDP, risk]
-dependencies: [SKILL-IA-01]
+dependencies:
+  - bayesian-sensor-belief-updater
 ---
 
-# SKILL-RE-01 · Inventory Uncertainty Quantifier
+# Inventory Uncertainty Quantifier
 
 ## When to Use This Skill
 
@@ -14,7 +15,7 @@ Activate this skill when the user asks about:
 - How reliable or trustworthy the current inventory estimate is
 - Whether the stock level estimate is precise enough to base a decision on
 - How stale the last physical count is and whether it affects confidence
-- As a prerequisite before `SKILL-PU-01`, `SKILL-DS-01`, `SKILL-MD-01`
+- As a prerequisite before `multi-attribute-utility-scorer`, `expected-utility-action-ranker`, `decision-confidence-estimator`
 - Questions like *"Can we trust this stock estimate for the allocation decision?"*
   or *"How uncertain is our inventory position for SKU-X in Warehouse Y?"*
 
@@ -22,7 +23,7 @@ Activate this skill when the user asks about:
 
 ## Core Concept
 
-A posterior belief `b(s) = N(μ, σ²)` from `SKILL-IA-01` quantifies what we know
+A posterior belief `b(s) = N(μ, σ²)` from `bayesian-sensor-belief-updater` quantifies what we know
 about the true inventory quantity. But the raw `σ` alone is not decision-ready —
 it needs to be combined with data staleness and quality status into a single
 normalised **uncertainty index** ∈ [0, 1].
@@ -78,12 +79,12 @@ expand_graph_by_ids(
 
 ---
 
-### Step 3: Retrieve SKILL-IA-01 outputs (upstream dependency)
+### Step 3: Retrieve `bayesian-sensor-belief-updater` outputs (upstream dependency)
 
-This skill requires the posterior from `SKILL-IA-01` as input.
+This skill requires the posterior from `bayesian-sensor-belief-updater` as input.
 If `data_gap_flag=True` is set on the upstream result, return safe default immediately.
 
-**Required fields from SKILL-IA-01:**
+**Required fields from `bayesian-sensor-belief-updater`:**
 `posterior_mean (μ)`, `posterior_std (σ)`, `effective_confidence`, `data_quality_label`
 
 ---
@@ -159,7 +160,7 @@ uncertainty_class = CERTAIN      if uncertainty_index <  0.10
 
 | Situation | Behaviour |
 |---|---|
-| SKILL-IA-01 `data_gap_flag=True` | Return `uncertainty_class=HIGH`, `uncertainty_index=1.0`, `data_gap_flag=True` |
+| `bayesian-sensor-belief-updater` `data_gap_flag=True` | Return `uncertainty_class=HIGH`, `uncertainty_index=1.0`, `data_gap_flag=True` |
 | `last_count_at` missing | Assume `staleness_days=30` (conservative) |
 | `posterior_mean=0` and `posterior_std=0` | `CV=0`, `uncertainty_class=CERTAIN` — flag as suspicious |
 | `quality_status=quarantine` or `damaged` | `quality_penalty=0.2`, add warning |
@@ -173,7 +174,7 @@ uncertainty_class = CERTAIN      if uncertainty_index <  0.10
 ```
 <thinking>
 I need to quantify how uncertain we are about the true inventory level
-before committing stock. I'll run SKILL-RE-01 on top of SKILL-IA-01 output.
+before committing stock. I'll run `inventory-uncertainty-quantifier` on top of `bayesian-sensor-belief-updater` output.
 </thinking>
 
 Step 1 — search_knowledge_base("entropy uncertainty measure belief distribution Gaussian differential entropy variance")
@@ -183,7 +184,7 @@ Step 2 — expand_graph_by_ids([doc_id_1, doc_id_2])
 → Confirmed: belief degrades without fresh observations (Ch.19 §19.1)
 → staleness penalty grows linearly at 0.02/day
 
-Step 3 — SKILL-IA-01 result:
+Step 3 — `bayesian-sensor-belief-updater` result:
     posterior_mean = 541.2,  posterior_std = 38.4
     effective_confidence = 0.73,  data_quality_label = "good"
 
@@ -214,7 +215,7 @@ Recommend: trigger a cycle count before committing, or apply safety buffer.
 
 ## Feeds Into
 
-- `SKILL-PU-02` — uses `uncertainty_index` to compute Value of Information (VOI)
-- `SKILL-DS-01` — uses `uncertainty_index` to compute confidence intervals around action scores
-- `SKILL-MD-01` — uses `uncertainty_class` as `c_uncertainty` factor in decision confidence
-- `SKILL-DS-03` — uses `uncertainty_index` to decide whether to defer or act immediately
+- `value-of-information` — uses `uncertainty_index` to compute Value of Information (VOI)
+- `expected-utility-action-ranker` — uses `uncertainty_index` to compute confidence intervals around action scores
+- `decision-confidence-estimator` — uses `uncertainty_class` as `c_uncertainty` factor in decision confidence
+- `threshold-based-trigger-decision` — uses `uncertainty_index` to decide whether to defer or act immediately

--- a/services/agent-service/skills/re02_leadtime_risk_estimator/SKILL.md
+++ b/services/agent-service/skills/re02_leadtime_risk_estimator/SKILL.md
@@ -3,10 +3,11 @@ name: leadtime-risk-estimator
 description: "Estimates statistical lead-time risk for a purchase order by fitting a mixture distribution over the base delivery time and rare delay scenarios, then inflating variance based on supplier reliability. Returns expected lead time, P95/P99 quantiles, and probability of exceeding a planning horizon. Use before issuing a PO, comparing suppliers on delivery risk, or stress-testing replenishment plans. Questions like 'Will this supplier deliver on time?', 'What is the worst-case lead time for this order?', 'How likely is a delay beyond 14 days?'"
 version: "1.0"
 tags: [lead-time, risk, supplier, procurement, mixture-distribution, quantile]
-dependencies: [SKILL-IA-02]
+dependencies:
+  - supplier-reliability-aggregator
 ---
 
-# SKILL-RE-02 · Lead-Time Risk Estimator
+# Lead-Time Risk Estimator
 
 ## When to Use This Skill
 
@@ -34,7 +35,7 @@ p(LT) = (1 − ρ) × F_base(p1, p2) + ρ × F_shifted(p1, p2 + rare_delay_add_d
 where `ρ = p_rare_delay`. This captures both normal delivery and occasional
 severe delays in a single model.
 
-Supplier reliability from `SKILL-IA-02` then inflates the mixture variance:
+Supplier reliability from `supplier-reliability-aggregator` then inflates the mixture variance:
 ```
 Var[LT]_adjusted = Var[LT]_base × (1 + (1 − reliability))
 ```
@@ -122,11 +123,11 @@ GET /api/v1/smart-query/procurement/pipeline-summary
 
 ---
 
-### Step 5: Fetch supplier reliability from SKILL-IA-02
+### Step 5: Fetch supplier reliability from `supplier-reliability-aggregator`
 
-Requires `posterior_mean_reliability` from `SKILL-IA-02` output for this supplier.
+Requires `posterior_mean_reliability` from `supplier-reliability-aggregator` output for this supplier.
 
-If `SKILL-IA-02` was not run, use `suppliers.reliability_score` as a fallback.
+If `supplier-reliability-aggregator` was not run, use `suppliers.reliability_score` as a fallback.
 
 ---
 
@@ -155,7 +156,7 @@ Var_shifted = p2²
 Var_mixture = w_base × (Var_base + p1²) + w_delay × (Var_shifted + (p1 + rare_delay_add_days)²) − E[LT]²
 
 # 6. Reliability inflation (Ch.14 §14.3 robustness perturbation)
-reliability = posterior_mean_reliability  (from SKILL-IA-02)
+reliability = posterior_mean_reliability  (from `supplier-reliability-aggregator`)
 Var_adjusted = Var_mixture × (1 + (1 − reliability))
 σ_adjusted   = sqrt(Var_adjusted)
 
@@ -194,7 +195,7 @@ risk_class = ACCEPTABLE  if P(LT > horizon) < 0.05
 | Situation | Behaviour |
 |---|---|
 | No `leadtime_model_id` on PO | Fall back to global-scope model, add warning |
-| `SKILL-IA-02` result unavailable | Use static `reliability_score`, `evidence_weight="weak"` |
+| `supplier-reliability-aggregator` result unavailable | Use static `reliability_score`, `evidence_weight="weak"` |
 | `p_rare_delay = 0` | Single-component distribution, no mixture needed |
 | `dist_family` not recognised | Default to normal distribution, add warning |
 | `prob_exceed_horizon` unavailable (no horizon given) | Omit field, return quantiles only |
@@ -225,7 +226,7 @@ Step 3 — search_knowledge_base("robustness modeling errors sensitivity varianc
 Step 4 — GET /purchase-orders/po-uuid-abc → leadtime_model_id = LM-07
 → dist_family=normal, p1=7.0, p2=1.5, p_rare_delay=0.12, rare_delay_add_days=8
 
-Step 5 — SKILL-IA-02 result:
+Step 5 — `supplier-reliability-aggregator` result:
 → posterior_mean_reliability = 0.765
 
 Step 6 — Compute:
@@ -256,7 +257,7 @@ or place the order now with 6+ days buffer to absorb the tail risk.
 
 ## Feeds Into
 
-- `SKILL-PU-01` — uses `risk_class` as `u_lt` factor in utility scoring
-- `SKILL-MD-01` — uses `risk_class` in decision confidence assessment
-- `SKILL-DS-02` — uses full distribution for stochastic dominance comparison across suppliers
-- `SKILL-DS-03` — uses `expected_lead_time_days` for pipeline coverage calculation
+- `multi-attribute-utility-scorer` — uses `risk_class` as `u_lt` factor in utility scoring
+- `decision-confidence-estimator` — uses `risk_class` in decision confidence assessment
+- `stochastic-dominance-filter` — uses full distribution for stochastic dominance comparison across suppliers
+- `threshold-based-trigger-decision` — uses `expected_lead_time_days` for pipeline coverage calculation

--- a/services/agent-service/skills/re03_regime_detector/SKILL.md
+++ b/services/agent-service/skills/re03_regime_detector/SKILL.md
@@ -6,7 +6,7 @@ tags: [inventory, regime, anomaly, adjustments, shrinkage, model-update]
 dependencies: []
 ---
 
-# SKILL-RE-03 · Inventory Flow Regime Detector
+# Inventory Flow Regime Detector
 
 ## When to Use This Skill
 
@@ -259,7 +259,7 @@ mostly coded as shrinkage. Not yet a confirmed regime shift (Bayesian confidence
 
 ## Feeds Into
 
-- `SKILL-MD-03` — uses `regime_label` to weight signal conflict resolution
-- `SKILL-MD-01` — applies confidence penalty when `regime_label = REGIME_SHIFT`
-- `SKILL-PU-02` — elevated regime triggers VOI recalculation (gather more info first)
-- `SKILL-DS-03` — `REGIME_SHIFT` overrides threshold trigger to conservative mode
+- `signal-conflict-resolver` — uses `regime_label` to weight signal conflict resolution
+- `decision-confidence-estimator` — applies confidence penalty when `regime_label = REGIME_SHIFT`
+- `value-of-information` — elevated regime triggers VOI recalculation (gather more info first)
+- `threshold-based-trigger-decision` — `REGIME_SHIFT` overrides threshold trigger to conservative mode


### PR DESCRIPTION
## Summary

Replace `SKILL-*` dependency references with canonical skill names to align skill references with the existing name-based resolution model.

## Problem

The skill store already resolves skills by canonical name via `_metadata_cache` and `_content_cache`, with `metadata.name` expected to match the directory name when `enforce_name_matches_dir=True`.

However, some skill dependencies and in-text references still used opaque `SKILL-*` identifiers such as `SKILL-PU-01`. These IDs do not match the current store lookup model, which loads and resolves skills by canonical skill name, making dependency references inconsistent with the existing architecture.

## Changes

- Replaced `SKILL-*` dependency references with canonical skill names
- Updated internal cross-references to use the same canonical names consistently

Example:

```yaml
dependencies:
  - multi-attribute-utility-scorer
  - constraint-satisfaction-validator
  - inventory-uncertainty-quantifier
