### PR TITLE
add more bind mounts, remove .env and unnecessary files from docker containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,7 @@ services:
     command: ["/app/.venv/bin/uvicorn", "environment_api.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
     volumes:
       - ./services/environment-api/src:/app/services/environment-api/src
+      - ./services/environment-api/config:/app/services/environment-api/config
       - ./packages/common:/app/packages/common
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health').status == 200 else 1)"]
@@ -76,6 +77,7 @@ services:
     command: ["/app/.venv/bin/uvicorn", "rag_service.main:app", "--host", "0.0.0.0", "--port", "8001", "--reload"]
     volumes:
       - ./services/rag-service/src:/app/src
+      - ./services/rag-service/config:/app/config
       - ./packages/common:/app/packages/common
     depends_on:
       weaviate:
@@ -106,6 +108,7 @@ services:
     volumes:
       - ./services/agent-service/app:/app/services/agent-service/app
       - ./services/agent-service/skills:/app/skills
+      - ./services/agent-service/config:/app/services/agent-service/config
       - ./packages/common:/app/packages/common
     depends_on:
       redis:

--- a/services/agent-service/Dockerfile
+++ b/services/agent-service/Dockerfile
@@ -32,6 +32,7 @@ COPY --from=builder /app/.venv /app/.venv
 COPY packages/common /app/packages/common
 COPY services/agent-service/app /app/services/agent-service/app
 COPY services/agent-service/config /app/services/agent-service/config
+COPY services/agent-service/skills /app/skills
 
 # Create non-root user
 RUN useradd -m -u 1000 agent && chown -R agent:agent /app

--- a/services/environment-api/Dockerfile
+++ b/services/environment-api/Dockerfile
@@ -31,4 +31,4 @@ COPY services/environment-api/config /app/services/environment-api/config
 
 EXPOSE 8000
 
-CMD ["uv", "run", "--frozen", "--project", "services/environment-api", "uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["/app/.venv/bin/uvicorn", "environment_api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/environment-api/Dockerfile
+++ b/services/environment-api/Dockerfile
@@ -3,9 +3,7 @@ FROM python:3.11-slim AS builder
 WORKDIR /app
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    PYTHONPATH=/app:/app/services/environment-api \
-    PORT=8000
+    PYTHONUNBUFFERED=1
 
 RUN pip install --no-cache-dir uv
 
@@ -15,6 +13,21 @@ COPY packages/database /app/packages/database
 COPY services/environment-api /app/services/environment-api
 
 RUN uv sync --frozen --project services/environment-api
+
+FROM python:3.11-slim AS runtime
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app:/app/services/environment-api \
+    PORT=8000
+
+COPY --from=builder /app/.venv /app/.venv
+COPY packages/common /app/packages/common
+COPY packages/database /app/packages/database
+COPY services/environment-api/src /app/services/environment-api/src
+COPY services/environment-api/config /app/services/environment-api/config
 
 EXPOSE 8000
 

--- a/services/rag-service/Dockerfile
+++ b/services/rag-service/Dockerfile
@@ -24,7 +24,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 COPY --from=builder /app/.venv /app/.venv
 COPY packages/common /app/packages/common
-COPY services/rag-service/src /app/src
+COPY services/rag-service/src/rag_service /app/src/rag_service
 COPY services/rag-service/config /app/config
 
 EXPOSE 8001


### PR DESCRIPTION
Changes made to Dockerfiles and docker compose config of agent, rag and environment services
- added bind mounts for config
- added skills to agent container. Ealier they were accessed only through bind mount
- removed .env file from environment container
- removed files not needed for fast api apps from environment and rag containers